### PR TITLE
Fix Arabic Shadda pairs are not composed

### DIFF
--- a/lib/src/paragraph.dart
+++ b/lib/src/paragraph.dart
@@ -405,12 +405,16 @@ class Paragraph {
           t == BidiCharacterType.S) {
         // find bounds of run of neutrals
         int runstart = i;
-        int runlimit = findRunLimit(runstart, limit, [
-          BidiCharacterType.B,
-          BidiCharacterType.S,
-          BidiCharacterType.WS,
-          BidiCharacterType.ON
-        ]);
+        int runlimit = findRunLimit(
+          runstart,
+          limit,
+          [
+            BidiCharacterType.B,
+            BidiCharacterType.S,
+            BidiCharacterType.WS,
+            BidiCharacterType.ON
+          ],
+        );
 
         // determine effective types at ends of run
         BidiCharacterType leadingType;
@@ -690,6 +694,10 @@ class Paragraph {
     return compose(String.fromCharCodes([first, second]));
   }
 
+  bool _isPartOfArabicShaddaPair(UnicodeCanonicalClass chClass) {
+    return chClass.value >= 28 && chClass.value <= 35;
+  }
+
   void internalCompose(List<int> target, List<int> charLengths) {
     if (target.isEmpty) {
       return;
@@ -719,7 +727,8 @@ class Paragraph {
       final composite = getPairwiseComposition(starterCh, ch);
       final composeType = getUnicodeDecompositionType(composite);
 
-      if (composeType == UnicodeDecompositionType.none &&
+      if ((composeType == UnicodeDecompositionType.none ||
+              _isPartOfArabicShaddaPair(chClass)) &&
           composite != BidiChars.NotAChar &&
           (lastClass.value < chClass.value ||
               lastClass == UnicodeCanonicalClass.NR)) {
@@ -729,7 +738,8 @@ class Paragraph {
         // so we don't have to adjust the decompPos
         starterCh = composite;
       } else {
-        if (chClass == UnicodeCanonicalClass.NR) {
+        if (chClass == UnicodeCanonicalClass.NR ||
+            _isPartOfArabicShaddaPair(chClass)) {
           starterPos = compPos;
           starterCh = ch;
         }

--- a/lib/src/unicode_character_resolver.dart
+++ b/lib/src/unicode_character_resolver.dart
@@ -4577,17 +4577,31 @@ const Map<String, int> composeMapping = {
   '\u0020\u0345': 0x037A,
   '\u0020\u064B': 0xFE70,
   '\u0020\u064C': 0xFE72,
+  // Arabic Shadda Isolated combinations
   '\u0020\u064C\u0651': 0xFC5E,
-  '\u0020\u064D': 0xFE74,
+  '\u064C\u0651': 0xFC5E,
+  '\u0651\u064C': 0xFC5E, // ccc28
   '\u0020\u064D\u0651': 0xFC5F,
-  '\u0020\u064E': 0xFE76,
+  '\u064D\u0651': 0xFC5F,
+  '\u0651\u064D': 0xFC5F, // ccc29
   '\u0020\u064E\u0651': 0xFC60,
-  '\u0020\u064F': 0xFE78,
+  '\u064E\u0651': 0xFC60,
+  '\u0651\u064E': 0xFC60, //ccc30
   '\u0020\u064F\u0651': 0xFC61,
-  '\u0020\u0650': 0xFE7A,
+  '\u064F\u0651': 0xFC61,
+  '\u0651\u064F': 0xFC61, //ccc31
   '\u0020\u0650\u0651': 0xFC62,
-  '\u0020\u0651': 0xFE7C,
+  '\u0650\u0651': 0xFC62,
+  '\u0651\u0650': 0xFC62, //ccc32
   '\u0020\u0651\u0670': 0xFC63,
+  '\u0651\u0670': 0xFC63,
+  '\u0670\u0651': 0xFC63,
+  // end
+  '\u0020\u064D': 0xFE74,
+  '\u0020\u064E': 0xFE76,
+  '\u0020\u064F': 0xFE78,
+  '\u0020\u0650': 0xFE7A,
+  '\u0020\u0651': 0xFE7C,
   '\u0020\u0652': 0xFE7E,
   '\u0020\u3099': 0x309B,
   '\u0020\u309A': 0x309C,
@@ -13576,7 +13590,19 @@ List<int> UgcList_Cf = [
   0xFEFF,
   1,
   0xFFF9,
-  3
+  3,
+  0xFC5E,
+  2,
+  0xFC5F,
+  2,
+  0xFC60,
+  2,
+  0xFC61,
+  2,
+  0xFC62,
+  2,
+  0xFC63,
+  2,
 ];
 List<int> UgcList_Cs = [0xD800, 1, 0xDB7F, 2, 0xDBFF, 2, 0xDFFF, 1];
 List<int> UgcList_Co = [0xE000, 1, 0xF8FF, 1];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bidi
 description: Implementation of the Bidi algorithm, as described in http://www.unicode.org/reports/tr9/tr9-17.html.
-version: 2.0.1
+version: 2.0.2
 repository: https://github.com/xclud/dart_bidi
 homepage: https://pwa.ir
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bidi
 description: Implementation of the Bidi algorithm, as described in http://www.unicode.org/reports/tr9/tr9-17.html.
-version: 2.0.2
+version: 2.0.1
 repository: https://github.com/xclud/dart_bidi
 homepage: https://pwa.ir
 

--- a/test/bidi_test.dart
+++ b/test/bidi_test.dart
@@ -36,7 +36,7 @@ void main() {
     };
     for(final pair in shaddaCompMapping.keys) {
        // we added dummy letter [\u0645]=> 65249 to get a real composition
-      expect(bidi.logicalToVisual('\u0645$pair'), [shaddaCompMapping[pair],65249]);
+      expect(bidi.logicalToVisual('\u0645$pair'), [shaddaCompMapping[pair], 65249]);
     }
   });
 }

--- a/test/bidi_test.dart
+++ b/test/bidi_test.dart
@@ -34,9 +34,12 @@ void main() {
       '\u0651\u0670': 64611,
       '\u0670\u0651': 64611,
     };
-    for(final pair in shaddaCompMapping.keys) {
-       // we added dummy letter [\u0645]=> 65249 to get a real composition
-      expect(bidi.logicalToVisual('\u0645$pair'), [shaddaCompMapping[pair], 65249]);
+    for (final pair in shaddaCompMapping.keys) {
+      // we added dummy letter [\u0645]=> 65249 to get a real composition
+      expect(
+        bidi.logicalToVisual('\u0645$pair'),
+        [shaddaCompMapping[pair], 65249],
+      );
     }
   });
 }

--- a/test/bidi_test.dart
+++ b/test/bidi_test.dart
@@ -18,4 +18,25 @@ void main() {
     expect(e, 'ﺆﻛ');
     expect(f, 'ﺊﻣ');
   });
+
+  test('Normalizing Arabic Shadda pairs', () {
+    final shaddaCompMapping = {
+      '\u064C\u0651': 64606,
+      '\u0651\u064C': 64606,
+      '\u064D\u0651': 64607,
+      '\u0651\u064D': 64607,
+      '\u064E\u0651': 64608,
+      '\u0651\u064E': 64608,
+      '\u064F\u0651': 64609,
+      '\u0651\u064F': 64609,
+      '\u0650\u0651': 64610,
+      '\u0651\u0650': 64610,
+      '\u0651\u0670': 64611,
+      '\u0670\u0651': 64611,
+    };
+    for(final pair in shaddaCompMapping.keys) {
+       // we added dummy letter [\u0645]=> 65249 to get a real composition
+      expect(bidi.logicalToVisual('\u0645$pair'), [shaddaCompMapping[pair],65249]);
+    }
+  });
 }


### PR DESCRIPTION
Hello @xclud 
In current implementation Arabic Shadda pairs are not composed properly inside of `internalCompose` method.

**Firstly, What are Arabic Shadda pairs?** 
Simply put, Arabic Shadda can be composed with some deictics and make a completely new deictic like follows

![Screen Shot 2022-11-06 at 2 57 55 PM](https://user-images.githubusercontent.com/55059449/200169716-d02e4945-ac9e-43ce-8b02-a2b852457d7a.png)

so without the fix this is how 2 deictics (Fatha + Shadda) look like.

![Screen Shot 2022-11-05 at 3 25 11 PM](https://user-images.githubusercontent.com/55059449/200169811-675db014-7d45-4481-9dc4-670ac543c8a1.png)
they're  supposed to be treated as one but instead they're rendered overlaid on each other.

and that's how it's supposed to look like ( which the fix does )

![Screen Shot 2022-11-06 at 3 09 44 PM](https://user-images.githubusercontent.com/55059449/200169894-60b4bb23-539e-4b02-af20-4951f40eb8ee.png)

